### PR TITLE
fix: pin Pipenv Python version for Dependabot

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -28,7 +28,7 @@ r2pipe = "==1.8.0"
 pathvalidate = "==3.2.3"
 
 [requires]
-python_version = ">=3.10"
+python_version = "3.10"
 
 [pipenv]
 allow_prereleases = true

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "a4a37c43b6903d442e026b344928ed2efc3ca02f225de9d382b93c513429eed1"
+            "sha256": "cd7a48deca43a95e93b76d61a71f2fb638f7891380580913ea9a59c7ab11dd98"
         },
         "pipfile-spec": 6,
         "requires": {


### PR DESCRIPTION
## Summary

- pin the Pipenv development environment to Python 3.10
- refresh only the `Pipfile.lock` metadata hash
- keep the package compatibility range (`python_requires >=3.10`) unchanged

## Why

Dependabot security updates currently fail before dependency resolution because `Pipfile` uses `python_version = ">=3.10"`, while Pipenv does not support Python version ranges. The existing lock metadata and the pytest workflow already target Python 3.10, so the exact development-environment pin makes those files consistent and allows Dependabot to proceed.

Failed update evidence: https://github.com/ev-flow/quark-engine/actions/runs/32075681591

## Validation

- `uvx --python 3.10 --from pipenv==2024.4.1 pipenv verify`
- `PYTHONUTF8=1 uv run --no-project --python 3.10 python setup.py --version` (`26.8.1`)
- `git diff --check`
