### PR TITLE
Add Quark malware analysis report for Dendroid

### DIFF
--- a/docs/source/malware_report.rst
+++ b/docs/source/malware_report.rst
@@ -3688,3 +3688,111 @@ The table below lists the APKs we tested.
 +-------+------------------------------------------------------------------+
 | 2     | BD8CDA80AAEE3E4A17E9967A1C062AC5C8E4AEFD7EAA3362F54044C2C94DB52A |
 +-------+------------------------------------------------------------------+
+
+Dendroid Malware Family Analysis Report
+=======================================
+
+This report analyses the `Dendroid <https://malpedia.caad.fkie.fraunhofer.de/details/apk.dendroid>`__ malware family using Quark's rule classification. Dendroid is a commercial Android RAT sold on underground forums from 2014, whose source code later leaked and seeded a number of derivatives. It is operated through a web panel and disguises itself as a parental-control application. This run did not add a new rule for Dendroid. Check `here <https://github.com/quark-engine/quark-rules>`__ for the rule set details.
+
+Quark's rule classification flagged **2 of 2 Dendroid samples** as high-risk in this experiment (detection rate **100%**). Benign-cohort false-positive rate was not measured here. Please check :ref:`here <list-of-tested-apks-dendroid>` for the APKs we tested.
+
+Identified Well-Known Threats
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The behaviours below are referenced from `MITRE ATT&CK® Mobile — S0301 Dendroid <https://attack.mitre.org/software/S0301>`__.
+
+This section uses MITRE ATT&CK Mobile as its reference taxonomy, anchored to the `S0301 Dendroid <https://attack.mitre.org/software/S0301>`__ software entry. Of the **8 techniques** documented for the family, Quark's static bytecode analysis confirms the **3 listed below**; see the coverage-gap notes at the end of this section for the other 5.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - MITRE Technique
+     - Real-world manifestation
+   * - T1429 Audio Capture
+     - Recording ambient audio or phone calls via microphone access for surveillance
+   * - T1533 Data from Local System
+     - Reading stored communication records — sent messages and call logs — from the device's own providers
+   * - T1636.004 SMS Messages
+     - Harvesting SMS message content including authentication codes and personal communications
+
+All behavior maps below were rendered from sample ``099a57328de9335c524f44514e225d50731c808145221affdd684d8b4dad5a1d.apk`` (package ``com.parental.control.v4``) — chosen as the representative sample whose detected behaviors most fully cover the documented profile of Dendroid. The other family sample was used to compute the detection-rate figure above.
+
+Each section below corresponds to one technique from the table above. Within each section we first quote the MITRE definition, then show the Quark behavior map extracted from the representative sample's bytecode, then walk through the call sequence and list the underlying rules.
+
+**1. T1429 Audio Capture**
+
+`T1429 Audio Capture — attack.mitre.org <https://attack.mitre.org/techniques/T1429>`__
+
+    **MITRE definition (T1429):** Adversaries may capture audio to collect information by leveraging standard operating system APIs of a mobile device. Examples of audio information adversaries may target include user conversations, surroundings, phone calls, or other sensitive information.
+
+.. image:: https://i.ibb.co/wrKXnMqY/t1429-audio-capture.png
+
+``RecordService;onStart`` directly invokes the MediaRecorder API to initialize the recorder and begin capturing audio. This call enables the service to record ambient sound without user interaction.
+
+Behaviors detected by Quark:
+
+* Initialize the recorder and start recording (#00198)
+
+**2. T1533 Data From Local System**
+
+`T1533 Data from Local System — attack.mitre.org <https://attack.mitre.org/techniques/T1533>`__
+
+    **MITRE definition (T1533):** Adversaries may search local system sources, such as file systems or local databases, to find files of interest and sensitive data prior to exfiltration. Access to local system data, which includes information stored by the operating system, often requires escalated privileges.
+
+.. image:: https://i.ibb.co/GfqXY4wn/t1533-data-from-local-system.png
+
+``MyService$getSentSms;doInBackground`` queries content providers through ContentResolver, including the SMS and call-log URIs, and pulls out message bodies and addresses. This task reads the messages the device has **sent**; the inbox side is covered separately under T1636.004 below.
+
+Behaviors detected by Quark:
+
+* Query data from URI (SMS, CALLLOGS) (#00011)
+* Read sensitive data(SMS, CALLLOG, etc) (#00077)
+* Query a URI and check the result (#00187)
+* Get the address of a SMS message (#00188)
+* Get the content of a SMS message (#00189)
+* Query a URI and append the result into a string (#00190)
+* Query device data with ContentResolver (#00212)
+* Query device data with ContentResolver and a URI parsed from a string (#00222)
+* Accessing sensitive data from content provider (#00271)
+
+**3. T1636.004 SMS Messages**
+
+`T1636.004 SMS Messages — attack.mitre.org <https://attack.mitre.org/techniques/T1636/004>`__
+
+    **MITRE definition (T1636.004):** Adversaries may utilize standard operating system APIs to gather SMS messages. On Android, this can be accomplished using the SMS Content Provider. iOS provides no standard API to access SMS messages.
+
+.. image:: https://i.ibb.co/p6Mx6SZN/t1636-004-sms-messages.png
+
+``MyService$getInboxSms;doInBackground`` queries the SMS inbox provider and extracts the body and sender address of each stored message. Where the task above reads sent messages, this one harvests everything the device has **received**.
+
+Behaviors detected by Quark:
+
+* Get the address of a SMS message (#00188)
+* Get the content of a SMS message (#00189)
+* Get messages in the SMS inbox (#00191)
+
+**Coverage-gap notes**
+
+The 5 MITRE techniques documented for Dendroid that this report does NOT demonstrate, grouped by the reason Quark could not confirm them:
+
+**Present in the samples but not shown as a section above (2)** — T1512 Video Capture and T1582 SMS Control. Quark confirms both at full data-flow depth inside Dendroid's own classes: ``Lcom/connect/CameraView`` reads and changes camera parameters while ``Lcom/connect/VideoView`` and ``MyService$recordAudio`` write recorded media to disk; ``MyService$deleteSms`` removes messages through the SMS content URI and ``MyService$sendText`` sends them. Both behaviours are real and attributable to the family — they are recorded here for completeness.
+
+**The samples do not exhibit the behaviour (1)** — T1655.001 Match Legitimate Name or Location. The matching rules do fire, but only inside bundled library code, so nothing here can be credited to Dendroid.
+
+**One of each rule's two APIs is absent (2)** — T1417.002 GUI Input Capture and T1633.001 System Checks. Quark confirms a rule only when both of its APIs appear in the APK, and for these two that never happens: the accessibility APIs the keylogging rules pair against are not called anywhere in the samples, and neither are the second halves of the device-check rules.
+
+.. _list-of-tested-apks-dendroid:
+
+List of Tested APKs
+~~~~~~~~~~~~~~~~~~~
+
+The table below lists the APKs we tested.
+
++-------+------------------------------------------------------------------+
+| index | sha256                                                           |
++=======+==================================================================+
+| 1     | 099A57328DE9335C524F44514E225D50731C808145221AFFDD684D8B4DAD5A1D |
++-------+------------------------------------------------------------------+
+| 2     | 0B8BA0C6CEBE5695639BF1B282B52F126DBA733F3C204E37615A3BA5F7DD6FE8 |
++-------+------------------------------------------------------------------+


### PR DESCRIPTION
# Dendroid Malware Family Analysis Report

This report analyses the [Dendroid](https://malpedia.caad.fkie.fraunhofer.de/details/apk.dendroid) malware family using Quark's rule classification. Dendroid is a commercial Android RAT sold on underground forums from 2014, whose source code later leaked and seeded a number of derivatives. It is operated through a web panel and disguises itself as a parental-control application. This run did not add a new rule for Dendroid. Check [here](https://github.com/quark-engine/quark-rules) for the rule set details.

Quark's rule classification flagged **2 of 2 Dendroid samples** as high-risk in this experiment (detection rate **100%**). Benign-cohort false-positive rate was not measured here. See [tested APKs](#list-of-tested-apks) below.

## Identified Well-Known Threats

This section uses MITRE ATT&CK Mobile as its reference taxonomy, anchored to the [S0301 Dendroid](https://attack.mitre.org/software/S0301) software entry. Of the **8 techniques** documented for the family, Quark's static bytecode analysis confirms the **3 listed below**; see the [coverage-gap notes](#coverage-gap-notes) at the end of this section for the other 5.

| MITRE Technique | Real-world manifestation |
|---|---|
| T1429 Audio Capture | Recording ambient audio or phone calls via microphone access for surveillance |
| T1533 Data from Local System | Reading stored communication records — sent messages and call logs — from the device's own providers |
| T1636.004 SMS Messages | Harvesting SMS message content including authentication codes and personal communications |

All behavior maps below were rendered from sample `099a57328de9335c524f44514e225d50731c808145221affdd684d8b4dad5a1d.apk` (package `com.parental.control.v4`) — chosen as the representative sample whose detected behaviors most fully cover the documented profile of Dendroid. The other family sample was used to compute the detection-rate figure above.

Each section below corresponds to one technique from the table above. Within each section we first quote the MITRE definition, then show the Quark behavior map extracted from the representative sample's bytecode, then walk through the call sequence and list the underlying rules.

### 1. T1429 Audio Capture

[T1429 Audio Capture — attack.mitre.org](https://attack.mitre.org/techniques/T1429)

> **MITRE definition (T1429):** Adversaries may capture audio to collect information by leveraging standard operating system APIs of a mobile device. Examples of audio information adversaries may target include user conversations, surroundings, phone calls, or other sensitive information.

![T1429 Audio Capture](https://i.ibb.co/wrKXnMqY/t1429-audio-capture.png)

`RecordService;onStart` directly invokes the MediaRecorder API to initialize the recorder and begin capturing audio. This call enables the service to record ambient sound without user interaction.

**Behaviors detected by Quark:**

- Initialize the recorder and start recording (#00198)

### 2. T1533 Data From Local System

[T1533 Data from Local System — attack.mitre.org](https://attack.mitre.org/techniques/T1533)

> **MITRE definition (T1533):** Adversaries may search local system sources, such as file systems or local databases, to find files of interest and sensitive data prior to exfiltration. Access to local system data, which includes information stored by the operating system, often requires escalated privileges.

![T1533 Data From Local System](https://i.ibb.co/GfqXY4wn/t1533-data-from-local-system.png)

`MyService$getSentSms;doInBackground` queries content providers through ContentResolver, including the SMS and call-log URIs, and pulls out message bodies and addresses. This task reads the messages the device has **sent**; the inbox side is covered separately under T1636.004 below.

**Behaviors detected by Quark:**

- Query data from URI (SMS, CALLLOGS) (#00011)
- Read sensitive data(SMS, CALLLOG, etc) (#00077)
- Query a URI and check the result (#00187)
- Get the address of a SMS message (#00188)
- Get the content of a SMS message (#00189)
- Query a URI and append the result into a string (#00190)
- Query device data with ContentResolver (#00212)
- Query device data with ContentResolver and a URI parsed from a string (#00222)
- Accessing sensitive data from content provider (#00271)

### 3. T1636.004 SMS Messages

[T1636.004 SMS Messages — attack.mitre.org](https://attack.mitre.org/techniques/T1636/004)

> **MITRE definition (T1636.004):** Adversaries may utilize standard operating system APIs to gather SMS messages. On Android, this can be accomplished using the SMS Content Provider. iOS provides no standard API to access SMS messages.

![T1636.004 SMS Messages](https://i.ibb.co/p6Mx6SZN/t1636-004-sms-messages.png)

`MyService$getInboxSms;doInBackground` queries the SMS inbox provider and extracts the body and sender address of each stored message. Where the task above reads sent messages, this one harvests everything the device has **received**.

**Behaviors detected by Quark:**

- Get the address of a SMS message (#00188)
- Get the content of a SMS message (#00189)
- Get messages in the SMS inbox (#00191)

### Coverage-gap notes

The 5 MITRE techniques documented for Dendroid that this report does NOT demonstrate, grouped by the reason Quark could not confirm them:

**Present in the samples but not shown as a section above (2)** — T1512 Video Capture and T1582 SMS Control. Quark confirms both at full data-flow depth inside Dendroid's own classes: `Lcom/connect/CameraView` reads and changes camera parameters while `Lcom/connect/VideoView` and `MyService$recordAudio` write recorded media to disk; `MyService$deleteSms` removes messages through the SMS content URI and `MyService$sendText` sends them. Both behaviours are real and attributable to the family — they are recorded here for completeness.

**The samples do not exhibit the behaviour (1)** — T1655.001 Match Legitimate Name or Location. The matching rules do fire, but only inside bundled library code, so nothing here can be credited to Dendroid.

**One of each rule's two APIs is absent (2)** — T1417.002 GUI Input Capture and T1633.001 System Checks. Quark confirms a rule only when both of its APIs appear in the APK, and for these two that never happens: the accessibility APIs the keylogging rules pair against are not called anywhere in the samples, and neither are the second halves of the device-check rules.

## List of Tested APKs

The table below lists the APKs we tested.

| index | sha256 |
|-------|--------|
| 1 | 099A57328DE9335C524F44514E225D50731C808145221AFFDD684D8B4DAD5A1D |
| 2 | 0B8BA0C6CEBE5695639BF1B282B52F126DBA733F3C204E37615A3BA5F7DD6FE8 |

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
